### PR TITLE
Fixed ExternalLink's href When There Is No "http" or "https" in the Old URL

### DIFF
--- a/src/components/ExternalLink.tsx
+++ b/src/components/ExternalLink.tsx
@@ -1,9 +1,18 @@
 import React from 'react';
 import { LinkProps, Link, Icon } from '@chakra-ui/core';
 
-const ExternalLink: React.FC<LinkProps> = ({ children, ...rest }) => {
+const ExternalLink: React.FC<LinkProps> = ({ children, href, ...rest }) => {
   return (
-    <Link color="purple.600" {...rest} isExternal>
+    <Link
+      color="purple.600"
+      {...rest}
+      href={
+        href?.startsWith('https://') || href?.startsWith('http://')
+          ? href
+          : `//${href}`
+      }
+      isExternal
+    >
       {children} <Icon name="external-link" mx="2px" />
     </Link>
   );


### PR DESCRIPTION
fixed #1 